### PR TITLE
Fix Telegram bot startup loop handling

### DIFF
--- a/beer_bot/main.py
+++ b/beer_bot/main.py
@@ -1,12 +1,12 @@
 """Entry point for the Beer Wednesday Telegram bot."""
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import NoReturn
 
 from dotenv import load_dotenv
 from telegram.ext import (
+    Application,
     ApplicationBuilder,
     CommandHandler,
     MessageHandler,
@@ -24,10 +24,8 @@ logging.basicConfig(
 LOGGER = logging.getLogger(__name__)
 
 
-async def run_bot() -> None:
-    """Initialise and start the Telegram bot."""
-    load_dotenv()
-    settings = Settings.load()
+def _build_application(settings: Settings) -> Application:
+    """Create the telegram application with all handlers configured."""
 
     application = ApplicationBuilder().token(settings.telegram_token).build()
 
@@ -47,14 +45,24 @@ async def run_bot() -> None:
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.handle_text))
     application.add_error_handler(handlers.error_handler)
 
+    return application
+
+
+def run_bot() -> None:
+    """Initialise and start the Telegram bot."""
+    load_dotenv()
+    settings = Settings.load()
+
+    application = _build_application(settings)
+
     LOGGER.info("Bot is running. Press Ctrl+C to stop.")
-    await application.run_polling(close_loop=False)
+    application.run_polling()
 
 
 def main() -> NoReturn:  # pragma: no cover - thin wrapper
-    """Synchronously run the async bot."""
+    """Synchronously run the bot."""
     try:
-        asyncio.run(run_bot())
+        run_bot()
     except KeyboardInterrupt:
         LOGGER.info("Bot stopped by user")
 


### PR DESCRIPTION
## Summary
- refactor bot startup to build the Telegram application synchronously
- avoid re-entering an already running asyncio loop by using Application.run_polling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3d2e1f85c83239973bc5333f88dc3