### PR TITLE
Handle decommissioned Groq vision model

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Beer Wednesday Bot
 
-Телеграм-бот, который принимает фото пива из чата, отправляет его в Groq Cloud (модели `llava-v1.5-7b-4096-preview` или `llama-3.2-11b-vision-preview`) и возвращает ироничный отзыв сомелье.
+Телеграм-бот, который принимает фото пива из чата, отправляет его в Groq Cloud (по умолчанию модель `llava-v1.5-7b-4096-preview`) и возвращает ироничный отзыв сомелье. Ранее использовавшаяся `llama-3.2-11b-vision-preview` Groq больше не поддерживает, поэтому при старом значении переменной окружения бот автоматически переключится на актуальную модель.
 
 ## Возможности
 
@@ -12,7 +12,7 @@
 ## Быстрый старт
 
 1. **Создайте бота у @BotFather** и получите токен.
-2. **Получите API-ключ Groq Cloud** на [console.groq.com](https://console.groq.com/) и убедитесь, что у вас есть доступ к модели `llava-v1.5-7b-4096-preview` или `llama-3.2-11b-vision-preview`.
+2. **Получите API-ключ Groq Cloud** на [console.groq.com](https://console.groq.com/) и убедитесь, что у вас есть доступ к модели `llava-v1.5-7b-4096-preview`. Если у вас в конфигурации осталась устаревшая `llama-3.2-11b-vision-preview`, удалите её из `GROQ_MODEL` или замените на новую модель из [списка Groq](https://console.groq.com/docs/deprecations).
 3. Скопируйте `.env.example` в `.env` и заполните значения:
    ```bash
    cp .env.example .env
@@ -45,7 +45,7 @@
 | --- | --- |
 | `TELEGRAM_BOT_TOKEN` | Токен бота из @BotFather. |
 | `GROQ_API_KEY` | API ключ Groq Cloud. |
-| `GROQ_MODEL` | (Опционально) Название модели Groq, по умолчанию `llama-3.2-11b-vision-preview`. |
+| `GROQ_MODEL` | (Опционально) Название модели Groq, по умолчанию `llava-v1.5-7b-4096-preview`. Устаревшие значения автоматически заменяются на актуальное по умолчанию. |
 | `GROQ_BASE_URL` | (Опционально) URL эндпоинта Chat Completions. |
 | `GROQ_TEMPERATURE` | (Опционально) Температура сэмплинга ответа. |
 | `GROQ_MAX_TOKENS` | (Опционально) Максимальное число токенов в ответе. |

--- a/beer_bot/config.py
+++ b/beer_bot/config.py
@@ -1,8 +1,12 @@
 """Configuration helpers for the Beer Wednesday bot."""
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -11,7 +15,7 @@ class Settings:
 
     telegram_token: str
     groq_api_key: str
-    groq_model: str = "llama-3.2-11b-vision-preview"
+    groq_model: str = "llava-v1.5-7b-4096-preview"
     groq_base_url: str = "https://api.groq.com/openai/v1/chat/completions"
     temperature: float = 0.7
     max_tokens: int = 1024
@@ -30,6 +34,19 @@ class Settings:
         groq_base_url = os.getenv("GROQ_BASE_URL", cls.groq_base_url)
         temperature_str = os.getenv("GROQ_TEMPERATURE")
         max_tokens_str = os.getenv("GROQ_MAX_TOKENS")
+
+        deprecated_models = {
+            "llama-3.2-11b-vision-preview": cls.groq_model,
+        }
+
+        if groq_model in deprecated_models:
+            replacement = deprecated_models[groq_model]
+            LOGGER.warning(
+                "Groq model '%s' is no longer supported. Falling back to '%s'.",
+                groq_model,
+                replacement,
+            )
+            groq_model = replacement
 
         missing = [
             name

--- a/beer_bot/groq_client.py
+++ b/beer_bot/groq_client.py
@@ -51,11 +51,11 @@ class GroqVisionClient:
 
         user_content: list[Dict[str, Any]] = [
             {
-                "type": "input_text",
+                "type": "text",
                 "text": caption or "Держи фото сегодняшнего крафта.",
             },
             {
-                "type": "input_image",
+                "type": "image_url",
                 "image_url": {"url": _image_to_data_url(image_bytes)},
             },
         ]
@@ -63,10 +63,7 @@ class GroqVisionClient:
         payload: Dict[str, Any] = {
             "model": self._model,
             "messages": [
-                {
-                    "role": "system",
-                    "content": [{"type": "input_text", "text": prompt}],
-                },
+                {"role": "system", "content": prompt},
                 {"role": "user", "content": user_content},
             ],
             "temperature": self._temperature,


### PR DESCRIPTION
## Summary
- add a warning-backed fallback when `GROQ_MODEL` is set to the deprecated `llama-3.2-11b-vision-preview`
- document the automatic fallback and point to Groq's deprecation list in the README

## Testing
- python -m compileall beer_bot

------
https://chatgpt.com/codex/tasks/task_e_68d3da181bf08323ad8ce5f52e136838