### PR TITLE
Add attendance poll to weekly notification

### DIFF
--- a/beer_bot/main.py
+++ b/beer_bot/main.py
@@ -12,6 +12,7 @@ from telegram.ext import (
     ApplicationBuilder,
     CommandHandler,
     MessageHandler,
+    PollAnswerHandler,
     filters,
 )
 
@@ -63,6 +64,7 @@ def _build_application(settings: Settings) -> Application:
     application.add_handler(CommandHandler("postcard", handlers.postcard_command))
     application.add_handler(MessageHandler(filters.PHOTO, handlers.handle_photo))
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.handle_text))
+    application.add_handler(PollAnswerHandler(handlers.handle_poll_answer))
     application.add_error_handler(handlers.error_handler)
 
     _schedule_weekly_postcard(application, settings)


### PR DESCRIPTION
## Summary
- send a weekly attendance poll together with the postcard reminder
- track poll answers and notify the chat when five or more people are coming
- register a poll answer handler to process attendance updates

## Testing
- python -m compileall beer_bot

------
https://chatgpt.com/codex/tasks/task_e_68d5016d45848323a11341fea987f8ad