### PR TITLE
Add postcard fallback when Hugging Face quota exceeded

### DIFF
--- a/beer_bot/postcard_client.py
+++ b/beer_bot/postcard_client.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import textwrap
+from datetime import datetime
+from io import BytesIO
 from typing import Any, Dict, Optional
 
 import httpx
+from PIL import Image, ImageDraw, ImageFont
 
 
 LOGGER = logging.getLogger(__name__)
@@ -74,6 +78,16 @@ class HuggingFacePostcardClient:
                 if response.status_code == httpx.codes.OK and content_type.startswith("image/"):
                     return response.content
 
+                if response.status_code == httpx.codes.PAYMENT_REQUIRED:
+                    LOGGER.warning(
+                        "Hugging Face вернул 402 — используем запасной шаблон открытки."
+                    )
+                    return self._render_fallback_postcard(
+                        prompt,
+                        width=width,
+                        height=height,
+                    )
+
                 if response.status_code == httpx.codes.ACCEPTED:
                     try:
                         wait_seconds = float(response.json().get("estimated_time", 3.0))
@@ -98,3 +112,86 @@ class HuggingFacePostcardClient:
                 response.raise_for_status()
 
         raise RuntimeError("Не удалось получить открытку от Hugging Face API")
+
+    def _render_fallback_postcard(
+        self,
+        prompt: str,
+        *,
+        width: int,
+        height: int,
+    ) -> bytes:
+        """Generate a simple postcard using Pillow when API is unavailable."""
+
+        image = Image.new("RGB", (width, height), "#191919")
+        draw = ImageDraw.Draw(image)
+
+        accent_color = "#f9a602"
+        secondary_color = "#353535"
+
+        draw.rectangle([(0, 0), (width, int(height * 0.22))], fill=secondary_color)
+        draw.rectangle([(0, height - int(height * 0.18)), (width, height)], fill=secondary_color)
+
+        title_font = self._load_font(68, bold=True)
+        subtitle_font = self._load_font(36, bold=True)
+        body_font = self._load_font(30)
+
+        title_text = "Beer Wednesday"
+        title_w, _ = draw.textsize(title_text, font=title_font)
+        draw.text(
+            ((width - title_w) / 2, int(height * 0.05)),
+            title_text,
+            font=title_font,
+            fill=accent_color,
+        )
+
+        date_text = datetime.now().strftime("%d %B %Y")
+        date_w, _ = draw.textsize(date_text, font=subtitle_font)
+        draw.text(
+            ((width - date_w) / 2, int(height * 0.16)),
+            date_text,
+            font=subtitle_font,
+            fill="white",
+        )
+
+        body_text = textwrap.fill(prompt.strip(), width=40)
+        draw.multiline_text(
+            (int(width * 0.08), int(height * 0.32)),
+            body_text,
+            font=body_font,
+            fill="white",
+            spacing=12,
+        )
+
+        footer_text = "Встретимся в баре!"
+        footer_w, _ = draw.textsize(footer_text, font=subtitle_font)
+        draw.text(
+            ((width - footer_w) / 2, height - int(height * 0.12)),
+            footer_text,
+            font=subtitle_font,
+            fill=accent_color,
+        )
+
+        buffer = BytesIO()
+        image.save(buffer, format="PNG")
+        return buffer.getvalue()
+
+    @staticmethod
+    def _load_font(
+        size: int, *, bold: bool = False
+    ) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+        """Try to load a TTF font with graceful fallback to the default bitmap font."""
+
+        font_candidates = [
+            "DejaVuSans-Bold.ttf" if bold else "DejaVuSans.ttf",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf" if bold else \
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        ]
+
+        for path in font_candidates:
+            try:
+                return ImageFont.truetype(path, size)
+            except OSError:
+                continue
+
+        # Pillow's default font is small, but ensures we still render text.
+        return ImageFont.load_default()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 httpx>=0.26.0
 python-telegram-bot>=21.4
 python-dotenv>=1.0.0
+Pillow>=10.0.0


### PR DESCRIPTION
## Summary
- return a generated template postcard when Hugging Face responds with HTTP 402
- render a simple Beer Wednesday poster with Pillow including prompt details
- declare Pillow as a dependency for the new fallback renderer

## Testing
- python -m compileall beer_bot

------
https://chatgpt.com/codex/tasks/task_e_68d509d8545083239a848ecc06da5563