### PR TITLE
Respond to direct beer questions as sommelier

### DIFF
--- a/beer_bot/groq_client.py
+++ b/beer_bot/groq_client.py
@@ -235,3 +235,21 @@ class GroqVisionClient:
             ],
             max_tokens=140,
         )
+
+    async def answer_beer_question(self, question: str) -> str:
+        """Respond to a beer-related question in the sommelier persona."""
+
+        prompt = (
+            "Ты — дружелюбный пивной сомелье. Отвечай только на вопросы о пиве, "
+            "его стилях, культуре пития, сочетаниях с едой и истории. Если "
+            "вопрос не про пиво, вежливо скажи, что общаешься лишь на пивные "
+            "темы. Будь кратким, но информативным и говори по-русски."
+        )
+
+        return await self._request_completion(
+            [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": question},
+            ],
+            max_tokens=220,
+        )


### PR DESCRIPTION
## Summary
- reply to direct text messages or mentions with a sommelier-style beer answer
- add Groq client helper to craft short beer-focused responses and reuse existing client configuration
- keep ignoring unrelated chatter unless the bot is directly addressed

## Testing
- python -m compileall beer_bot

------
https://chatgpt.com/codex/tasks/task_e_68d517192fa4832397d4893df18b67db