### PR TITLE
Adjust postcard schedule to 21:00 Asia/Almaty

### DIFF
--- a/beer_bot/config.py
+++ b/beer_bot/config.py
@@ -72,7 +72,7 @@ class Settings:
     postcard_prompt: str = DEFAULT_POSTCARD_PROMPT
     postcard_negative_prompt: Optional[str] = DEFAULT_POSTCARD_NEGATIVE_PROMPT
     postcard_caption: str = DEFAULT_POSTCARD_CAPTION
-    postcard_timezone: str = "Europe/Moscow"
+    postcard_timezone: str = "Asia/Almaty"
     postcard_scenarios: List[str] = field(
         default_factory=lambda: list(DEFAULT_POSTCARD_SCENARIOS)
     )

--- a/beer_bot/main.py
+++ b/beer_bot/main.py
@@ -110,14 +110,14 @@ def _schedule_weekly_postcard(application: Application, settings: Settings) -> N
 
     application.job_queue.run_daily(
         handlers.scheduled_postcard_job,
-        time=time(hour=19, minute=0, tzinfo=tzinfo),
+        time=time(hour=21, minute=0, tzinfo=tzinfo),
         days=(2,),  # Tuesday (0=sunday)
         data={"prompt": settings.postcard_prompt},
         name="weekly_beer_postcard",
         chat_id=settings.postcard_chat_id,
     )
     LOGGER.info(
-        "Weekly postcard job scheduled for chat %s at 19:00 %s every Tuesday.",
+        "Weekly postcard job scheduled for chat %s at 21:00 %s every Tuesday.",
         settings.postcard_chat_id,
         settings.postcard_timezone,
     )


### PR DESCRIPTION
## Summary
- switch the default postcard timezone to Asia/Almaty
- reschedule the weekly postcard job to 21:00 local time and update logging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e530a30c2483239b5f0e8671ea4a95