### PR TITLE
Ensure debug_postcards command works when parsed as plain text

### DIFF
--- a/beer_bot/handlers.py
+++ b/beer_bot/handlers.py
@@ -247,6 +247,16 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 
             return
 
+    if message.text:
+        trimmed_text = message.text.strip()
+        if trimmed_text.startswith("/"):
+            command = trimmed_text.split(None, 1)[0]
+            command_name = command[1:].split("@", 1)[0].lower()
+
+            if command_name == "debug_postcards":
+                await debug_postcards_command(update, context)
+                return
+
     bot_username = getattr(context.bot, "username", None)
     bot_id = getattr(context.bot, "id", None)
 


### PR DESCRIPTION
## Summary
- handle /debug_postcards commands that arrive as plain text messages without command entities

## Testing
- python -m compileall beer_bot

------
https://chatgpt.com/codex/tasks/task_e_68e540de9fac8323877dafbd361e3287