### PR TITLE
Allow attendance poll results to be viewed without voting

### DIFF
--- a/beer_bot/handlers.py
+++ b/beer_bot/handlers.py
@@ -533,6 +533,7 @@ async def _start_attendance_poll(
         ],
         is_anonymous=False,
         allows_multiple_answers=False,
+        api_kwargs={"allow_view_results_without_vote": True},
     )
 
     if not poll_message.poll:


### PR DESCRIPTION
## Summary
- send attendance polls with the Telegram API flag that keeps results visible to non-voters
- drop the extra summary message logic so the standard poll UI remains in use

## Testing
- python -m compileall beer_bot

------
https://chatgpt.com/codex/tasks/task_e_68e56416a8208323a1312239a7ad0537