### PR TITLE
Use placeholder postcard when Hugging Face client is unavailable

### DIFF
--- a/beer_bot/postcard_client.py
+++ b/beer_bot/postcard_client.py
@@ -16,10 +16,11 @@ from PIL import Image, ImageDraw, ImageFont
 LOGGER = logging.getLogger(__name__)
 
 
+PLACEHOLDER_POSTCARD_PATH = Path(__file__).resolve().parent / "postcard_placeholder.jpg"
+
+
 class HuggingFacePostcardClient:
     """Tiny wrapper around the Hugging Face text-to-image endpoint."""
-
-    _PLACEHOLDER_PATH = Path(__file__).resolve().parent / "postcard_placeholder.jpg"
 
     def __init__(
         self,
@@ -126,7 +127,7 @@ class HuggingFacePostcardClient:
         """Generate a simple postcard using Pillow when API is unavailable."""
 
         try:
-            with Image.open(self._PLACEHOLDER_PATH) as placeholder:
+            with Image.open(PLACEHOLDER_POSTCARD_PATH) as placeholder:
                 postcard = placeholder.convert("RGB")
                 if postcard.size != (width, height):
                     postcard = postcard.resize((width, height), Image.LANCZOS)


### PR DESCRIPTION
## Summary
- add a placeholder postcard fallback so manual commands keep responding even without the Hugging Face client
- expose the postcard placeholder path for reuse across modules

## Testing
- python -m compileall beer_bot

------
https://chatgpt.com/codex/tasks/task_e_68ee291db23883238530e8af8f7de5c4