### PR TITLE
Ensure postcard fallback image is sent on generation failure

### DIFF
--- a/beer_bot/handlers.py
+++ b/beer_bot/handlers.py
@@ -704,6 +704,18 @@ async def _send_postcard(
         )
     except Exception:  # pragma: no cover - runtime guard
         LOGGER.exception("Failed to generate postcard")
+        placeholder_bytes = _load_placeholder_postcard(path=placeholder_path)
+
+        if placeholder_bytes is not None:
+            LOGGER.info("Sending placeholder postcard due to generation failure")
+            await context.bot.send_photo(
+                chat_id=chat_id,
+                photo=placeholder_bytes,
+                caption=caption_to_send,
+                reply_to_message_id=reply_to_message_id,
+            )
+            return True
+
         fail_text = "Не получилось сгенерировать открытку, попробуй позже."
         if reply_to_message_id:
             await context.bot.send_message(


### PR DESCRIPTION
## Summary
- send the bundled placeholder postcard when Hugging Face generation fails
- keep the failure notification as a final fallback if the placeholder cannot be read

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6909b60b5d8c8323978a83f618c64caa