### PR TITLE
Ensure barhopping notifications work with default config

### DIFF
--- a/beer_bot/main.py
+++ b/beer_bot/main.py
@@ -104,11 +104,8 @@ def _schedule_weekly_postcard(application: Application, settings: Settings) -> N
         )
         return
 
-    if "postcard_client" not in application.bot_data:
-        LOGGER.warning(
-            "Postcard client не сконфигурирован — пропускаем расписание открыток."
-        )
-        return
+    # Note: We don't block scheduling if postcard_client is missing.
+    # The handler will send a placeholder image instead.
 
     try:
         tzinfo = ZoneInfo(settings.postcard_timezone)
@@ -145,7 +142,7 @@ def _schedule_barhopping_notification(application: Application, settings: Settin
     """Register a Thursday reminder for the monthly barhopping meetup."""
 
     if not settings.barhopping_chat_id:
-        LOGGER.info("BARGHOPPING_CHAT_ID не задан — ежемесячная рассылка отключена.")
+        LOGGER.info("BARHOPPING_CHAT_ID не задан — ежемесячная рассылка отключена.")
         return
 
     if application.job_queue is None:
@@ -157,11 +154,8 @@ def _schedule_barhopping_notification(application: Application, settings: Settin
         )
         return
 
-    if "postcard_client" not in application.bot_data:
-        LOGGER.warning(
-            "Postcard client не сконфигурирован — пропускаем расписание бархоппинга."
-        )
-        return
+    # Note: We don't block scheduling if postcard_client is missing.
+    # The handler will send a placeholder image instead.
 
     try:
         tzinfo = ZoneInfo(settings.barhopping_timezone)

--- a/beer_bot/tests/test_config_fallback.py
+++ b/beer_bot/tests/test_config_fallback.py
@@ -1,0 +1,33 @@
+import unittest
+import os
+from unittest.mock import patch
+from beer_bot.config import Settings
+
+class TestConfigFallback(unittest.TestCase):
+    @patch.dict(os.environ, {
+        "TELEGRAM_BOT_TOKEN": "test_token",
+        "GROQ_API_KEY": "test_key",
+        "POSTCARD_CHAT_ID": "99999"
+    }, clear=True)
+    def test_barhopping_inherits_postcard_chat_id(self):
+        """Test that barhopping_chat_id falls back to postcard_chat_id if not set."""
+        settings = Settings.load()
+        self.assertEqual(settings.postcard_chat_id, 99999)
+        self.assertEqual(settings.barhopping_chat_id, 99999)
+        self.assertEqual(settings.barhopping_timezone, "Asia/Almaty") # Default
+        self.assertEqual(settings.barhopping_hour, 12) # Default
+
+    @patch.dict(os.environ, {
+        "TELEGRAM_BOT_TOKEN": "test_token",
+        "GROQ_API_KEY": "test_key",
+        "POSTCARD_CHAT_ID": "99999",
+        "BARHOPPING_CHAT_ID": "88888"
+    }, clear=True)
+    def test_barhopping_explicit_overrides_fallback(self):
+        """Test that explicit barhopping_chat_id overrides the fallback."""
+        settings = Settings.load()
+        self.assertEqual(settings.postcard_chat_id, 99999)
+        self.assertEqual(settings.barhopping_chat_id, 88888)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/beer_bot/tests/test_date_logic.py
+++ b/beer_bot/tests/test_date_logic.py
@@ -1,0 +1,27 @@
+import unittest
+from datetime import date
+from beer_bot.handlers import _is_penultimate_friday
+
+class TestDateLogic(unittest.TestCase):
+    def test_penultimate_friday_normal_month(self):
+        # August 2024: 2, 9, 16, 23, 30. Penultimate: 23.
+        self.assertTrue(_is_penultimate_friday(date(2024, 8, 23)))
+        self.assertFalse(_is_penultimate_friday(date(2024, 8, 30)))
+        self.assertFalse(_is_penultimate_friday(date(2024, 8, 16)))
+
+    def test_penultimate_friday_leap_year_feb(self):
+        # Feb 2024: 2, 9, 16, 23. Penultimate: 16.
+        self.assertTrue(_is_penultimate_friday(date(2024, 2, 16)))
+        self.assertFalse(_is_penultimate_friday(date(2024, 2, 23)))
+
+    def test_penultimate_friday_4_fridays(self):
+        # Feb 2023: 3, 10, 17, 24. Penultimate: 17.
+        self.assertTrue(_is_penultimate_friday(date(2023, 2, 17)))
+        self.assertFalse(_is_penultimate_friday(date(2023, 2, 24)))
+
+    def test_not_a_friday(self):
+        # Aug 22, 2024 is Thursday
+        self.assertFalse(_is_penultimate_friday(date(2024, 8, 22)))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Updated `beer_bot/main.py` to allow scheduling notifications even if `postcard_client` is not configured (falls back to placeholder image).
- Fixed typo in log message: `BARGHOPPING_CHAT_ID` -> `BARHOPPING_CHAT_ID`.
- Verified in `beer_bot/config.py` that `barhopping_chat_id` correctly falls back to `postcard_chat_id` when missing.
- Added verification tests in `beer_bot/tests/` for configuration fallback and date logic.